### PR TITLE
Corrigindo variáveis dynaconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Esse projeto utiliza o [dynaconf](https://github.com/rochacbruno/dynaconf/)
 para gerenciar suas configurações. Um arquivo [settings](/config/settings.toml)
 na pasta `config` contém as configurações que devem ser 
 carregadas de acordo com o ambiente que a aplicação está
-rodando, conforme recomenda as recomendações do 
+rodando, conforme recomendado em 
 [12 factor](https://12factor.net/).
 
 Uma variável de ambiente `ENV_FOR_DYNACONF` contém
@@ -73,8 +73,16 @@ estar utilizando a extensão `dynaconf` para `Flask`
 ([flask-extension](https://dynaconf.readthedocs.io/en/2.2.3/guides/flask.html)),
 que injeta configurações de ambiente nas configurações
 da aplicação que podem ser acessadas via `app.config`.
-Além de facilitar o desenvolvimento, facilita a injeção
-de configurações utilizando uma única lib.
+Além de facilitar o desenvolvimento, facilita a integração
+de configurações utilizando uma única lib. Para alterar, 
+via variável de ambiente, uma configuração do `flask`,
+como, por exemplo, a *string* de conexão utilizada pelo
+`SQLAlchemy`, deve-se utilizar:
+```shell script
+export FLASK_SQLALCHEMY_DATABASE_URI='minhastringdeconexao'
+```
+Atenção ao prefixo `FLASK_`, que deve ser utilizado. 
+Isso pode ser alterado também.
 
 Fique à vontade para livremente excluir, alterar e 
 incluir configurações.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,6 @@ from flask_cors import CORS
 from .models.db import db, ma
 from flask_migrate import Migrate
 from .logger import logger
-import os
 
 
 __author__ = "Igor Cavalcanti"
@@ -36,7 +35,7 @@ def create_app():
         app.wsgi_app, prefix=settings.API_PREFIX
     )
 
-    FlaskDynaconf(app)
+    FlaskDynaconf().init_app(app)
 
     # registra as blueprints de resources
     from .resources.campus import bp as bp_campus
@@ -49,8 +48,8 @@ def create_app():
 
     db.init_app(app)
     ma.init_app(app)
-    migrate = Migrate(app, db)  # noqa: F841
-    CORS(app)
+    Migrate().init_app(app, db)
+    CORS().init_app(app)
 
     app.before_request(logger.request)
     app.before_request(get_tenant)

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -1,10 +1,9 @@
 [default]
 DEBUG = false
 TESTING = false
-FLASK_SQLALCHEMY_TRACK_MODIFICATIONS = false
-FLASK_JSON_AS_ASCII = false
-FLASK_SQLALCHEMY_DATABASE_URI = "sqlite:///flaskeleton.db"
-FLASK_SQLALCHEMY_BINDS = { development="sqlite:///flaskeleton.db", production="sqlite:///flaskeleton.db" }
+SQLALCHEMY_TRACK_MODIFICATIONS = false
+JSON_AS_ASCII = false
+SQLALCHEMY_BINDS = { development="sqlite:///flaskeleton.db", production="sqlite:///myproduction.db" }
 DEFAULT_TENANT = "development"
 ENABLE_MULTI_TENANT = true
 API_PREFIX = "/flaskeleton-api"
@@ -18,7 +17,7 @@ configs = "here"
 [testing]
 DEBUG = true
 TESTING = true
-FLASK_SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
 ENABLE_MULTI_TENANT = false
 
 [production]


### PR DESCRIPTION
As variáveis com prefixo `FLASK_` não são utilizadas no arquivo `setting.toml`, mas apenas quando setadas como variável de ambiente.