### PR TITLE
Corrigindo configurações SQLAlchemy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,5 +66,5 @@ prettier: ## Formata o codigo para torna-lo mais bonito
 lint: ## Verifica qualidade da escrita de codigo
 	flake8 ./app
 
-build-apidocs:
-    docker run -it --rm -v $(pwd):/application -w /application markteam/docker-aglio:latest aglio -i ./application/app/docs/api-blueprint-sample.apib --theme-full-width --no-theme-condense -o ./application/app/templates/apidocs/index.html
+build-apidocs: ## Gera documentacao com base no arquivo das especificacoes do API Blueprint
+	docker run -it --rm -v $(pwd):/application -w /application markteam/docker-aglio:latest aglio -i ./application/app/docs/api-blueprint-sample.apib --theme-full-width --no-theme-condense -o ./application/app/templates/apidocs/index.html

--- a/README.md
+++ b/README.md
@@ -127,6 +127,35 @@ da base de dados no container.
 make create-db
 ```
 
+#### Multi-Tenant
+Para solucionar um problema específico de domínio de problema,
+a API foi criada para responder requisições multicontexto.
+Ou seja, a mesma requisição pode carregar um contexto no cabeçalho
+da requisição para apontar qual banco de dados deseja utilizar
+(*multi-tenant*).
+
+Para não haver problemas com o funcionamento do *SQLAlchemy*
+e o *script* de *migrate*, existe nas configurações a variável
+`SQLALCHEMY_DATABASE_URI` que determina a base de dados *default*,
+ou seja, aquela que irá ser criada por padrão. Há ainda
+a variável `SQLALCHEMY_BINDS` que contém os mapeamentos disponíveis
+(nesse caso, `production` é ilustrativo e aponta para uma
+base de dados inexistente). A variável `DEFAULT_TENANT` 
+é responsável por indicar qual o `bind` padrão em caso de não
+fornecimento via cabeçalho do `bind` a ser utilizado. Por fim,
+o *multi-tenant* pode ser desabilitado por meio da variável
+`ENABLE_MULTI_TENANT`.
+
+Todas as variáveis podem ser livremente configuradas de acordo
+com a necessidade do desenvolvedor, inclusive desabilitando
+o recurso de multicontexto.
+
+> Tip: pode-se criar uma cópia do arquivo `flaskeleton.db` criado
+> no passo anterior e renomeá-lo para `production.db` para
+> testar o funcionamento do multi-contexto (lembre-se de passar
+> o contexto no cabeçalho por meio de `Context` para alternar
+> entre os `binds`).
+
 #### Documentação da API
 
 Para acessar a documentação da API, acesse a seguinte rota:

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -3,7 +3,8 @@ DEBUG = false
 TESTING = false
 SQLALCHEMY_TRACK_MODIFICATIONS = false
 JSON_AS_ASCII = false
-SQLALCHEMY_BINDS = { development="sqlite:///flaskeleton.db", production="sqlite:///myproduction.db" }
+SQLALCHEMY_DATABASE_URI = "sqlite:///flaskeleton.db"
+SQLALCHEMY_BINDS = { development="sqlite:///flaskeleton.db", production="sqlite:///production.db" }
 DEFAULT_TENANT = "development"
 ENABLE_MULTI_TENANT = true
 API_PREFIX = "/flaskeleton-api"

--- a/migrations/versions/30d1aafb0453_.py
+++ b/migrations/versions/30d1aafb0453_.py
@@ -1,8 +1,8 @@
 """empty message
 
-Revision ID: 8988c0482a42
+Revision ID: 30d1aafb0453
 Revises: 
-Create Date: 2020-04-04 20:37:32.196850
+Create Date: 2020-06-29 14:02:52.019865
 
 """
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '8988c0482a42'
+revision = '30d1aafb0453'
 down_revision = None
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
Uma correção nas configurações do `SQLAlchemy` adicionando uma string de conexão padrão para geração da base de dados. Incrementando documentação com seção sobre Multi-Contexto.